### PR TITLE
Add multiple variants of WSL image (base and java17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ The following scenarios have been tested as working with no other intervention o
 
 Fetch, import, and start [wsl-vpnkit](https://github.com/sakai135/wsl-vpnkit) by running the script [install-vpnkit.ps1](./install-vpnkit.ps1).
 
-Build and install the "RHEL9" WSL distribution by running the script [install.ps1](./install.ps1).
+Build and install the "RHEL9" WSL distribution by running one of the following scripts depending on your needs:
+-  [install-wsl.ps1](./install-wsl.ps1) (Base WSL image)
+-  [install-wsl-java17.ps1](./install-wsl-java17.ps1) (Base + JDK 17 and Maven)
 
 > **NOTE:** This script will wipe and remove any existing distribution with the name "RHEL9" distrubution if you already have one!
 

--- a/containers/dev-base.Containerfile
+++ b/containers/dev-base.Containerfile
@@ -16,6 +16,7 @@ RUN dnf update -y \
         nano \
         crudini \
         podman \
+        jq \
         && \
     dnf clean all -y
 

--- a/containers/dev-java17.Containerfile
+++ b/containers/dev-java17.Containerfile
@@ -1,14 +1,24 @@
 FROM rhelubi9:dev-base
 
 ARG USERNAME=java17
+ARG MAVEN_VERSION=3.9.5
 
 RUN dnf update -y \
         && \
     dnf install -y \
         java-17-openjdk-headless \
-        maven \
         && \
     dnf clean all -y
+
+# Install Maven
+ADD https://dlcdn.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz /tmp/maven/
+RUN tar xzf /tmp/maven/apache-maven-*.tar.gz -C /tmp/maven/ && \
+    mv /tmp/maven/apache-maven-${MAVEN_VERSION} /opt/apache-maven && \
+    alternatives --install /usr/local/bin/mvn mvn /opt/apache-maven/bin/mvn 1 && \
+    rm -rf /tmp/maven && \
+    echo "export MAVEN_HOME=/opt/apache-maven" >> /etc/profile && \
+    echo "export M2_HOME=\$MAVEN_HOME" >> /etc/profile && \
+    echo "export M2=\$M2_HOME/bin" >> /etc/profile
 
 # Add dev username
 RUN adduser -G wheel $USERNAME

--- a/containers/extras/wsl-user-setup.sh
+++ b/containers/extras/wsl-user-setup.sh
@@ -33,6 +33,13 @@ echo export PROMPT=\"\%\{\$fg_bold\[green\]\%\}\%n\%\{\$reset_color\%\} \$PROMPT
 runuser -u $username -- rm --force /home/$username/.gitconfig
 runuser -u $username -- ln --symbolic $GIT_CONFIG_GLOBAL /home/$username/.gitconfig
 
+# Remove user's Maven $HOME/.m2/settings.xml and create profile script to always copy the Windows file in each session (so it can be mounted to child containers)
+if [ -n "${MAVEN_SETTINGS}" ]; then
+    runuser -u $username -- rm --force /home/$username/.m2/settings.xml
+    runuser -u $username -- mkdir -p /home/$username/.m2
+    echo "cp $MAVEN_SETTINGS /home/$username/.m2/settings.xml" >> /etc/profile
+fi
+
 # Start user's session
 echo
 echo "Welcome to Linux, $username!"

--- a/containers/wsl-java17.Containerfile
+++ b/containers/wsl-java17.Containerfile
@@ -1,14 +1,17 @@
-FROM rhelubi9:dev-base
+FROM rhelubi9:wsl
 
-ARG USERNAME=java11
 ARG MAVEN_VERSION=3.9.5
 
 RUN dnf update -y \
         && \
     dnf install -y \
-        java-11-openjdk-headless \
+        java-17-openjdk-devel \
         && \
     dnf clean all -y
+
+# Add default MAVEN_ARGS to default profile
+RUN echo 'MAVEN_ARGS="--settings $MAVEN_SETTINGS"' >> /etc/profile && \
+    echo export MAVEN_ARGS >> /etc/profile
 
 # Install Maven
 ADD https://dlcdn.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz /tmp/maven/
@@ -19,15 +22,3 @@ RUN tar xzf /tmp/maven/apache-maven-*.tar.gz -C /tmp/maven/ && \
     echo "export MAVEN_HOME=/opt/apache-maven" >> /etc/profile && \
     echo "export M2_HOME=\$MAVEN_HOME" >> /etc/profile && \
     echo "export M2=\$M2_HOME/bin" >> /etc/profile
-
-# Add dev username
-RUN adduser -G wheel $USERNAME
-
-# Add and configure zsh
-RUN curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh | runuser -u $USERNAME -- sh -
-RUN chsh --shell /bin/zsh $USERNAME
-# Add username to zsh prompt
-RUN echo >> /home/$USERNAME/.zshrc && echo export PROMPT=$DEV_CONTAINER_ZSH_PROMPT >> /home/$USERNAME/.zshrc
-
-USER $USERNAME
-WORKDIR /home/$USERNAME

--- a/install-wsl-java17.ps1
+++ b/install-wsl-java17.ps1
@@ -1,0 +1,1 @@
+./install.ps1 wsl-java17

--- a/install-wsl.ps1
+++ b/install-wsl.ps1
@@ -1,0 +1,1 @@
+./install.ps1 wsl


### PR DESCRIPTION
- created new container with tag "wsl-java17" with JDK 17 and Maven plus added some extra goodies for passing Maven settings.xml from Windows to WSL (sort of same idea as with Git config)
- upgraded Maven from 3.6.x that comes with EPEL (plus forced an install of Java 11 even if you run something else) to latest 3.9.5 package from their site that does not depend on any specifc version of Java (did this in both Java dev container images plus the new wsl-java17 container image)
- added parameter to install.ps1 so you can give an image tag that should be "installed" as your WSL environment
- created install script for "wsl" and "wsl-java17" tags
- add jq to dev-base