### PR TITLE
Add Google Tinkey CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 This is a sample WSL distribution of Red Hat Universal Base Image 9 with some specific configurations for usage at Karolinska Hospital:
 
+- Assumes you are connected to the Region Stockholm network (VPN or on-site) in order to download certain resources.
 - Adds various Region Stockholm and Inera SITHS certificate authorities to the trust store.
 - Installs and configures the following utilities:
   - `terraform`
@@ -13,6 +14,25 @@ This is a sample WSL distribution of Red Hat Universal Base Image 9 with some sp
 - Installs and configures [zsh](https://www.zsh.org/) as the default shell for this default user, plus adds [Oh My Zsh!](https://github.com/ohmyzsh/ohmyzsh) with some extra plugins depending on response to a few prompts.
 - Assumes you have installed v0.4.x+ of [wsl-vpnkit](https://github.com/sakai135/wsl-vpnkit) and configures the RHEL9 WSL distrubtion with a systemd service to keep it running in the background as long as RHEL9 is running (see [Installing](#installing) below).
 - Assumes you have installed [Git for Windows](https://git-scm.com/download/win) >= v2.39.0 and that you have set up all of your config as needed with Git for Windows including Git Credential Manager.
+
+## WSL Setup
+
+Make sure you have at least WSL version 2.0.14.0 or higher.
+
+Check the WSL version using the command `wsl --version`.
+
+```bat
+> wsl --version
+WSL-version: 2.0.14.0
+Kernelversion: 5.15.133.1-1
+WSLg-version: 1.0.59
+MSRDC-version: 1.2.4677
+Direct3D-version: 1.611.1-81528511
+DXCore-version: 10.0.25131.1002-220531-1700.rs-onecore-base2-hyp
+Windows-version: 10.0.19045.3803
+```
+
+Upgrade WSL if it is not at least 2.0.14.0 from Microsoft Store or with the command `wsl --upgrade`.
 
 ## Git Setup
 

--- a/containers/extras/systemd/wsl-vpnkit.service
+++ b/containers/extras/systemd/wsl-vpnkit.service
@@ -6,8 +6,7 @@ After=network.target
 
 [Service]
 # for wsl-vpnkit setup as a distro
-# set GVPROXY_PATH to the copy of wsl-gvproxy.exe that install-vpnkit.ps1 creates in C:\git\wsl-vpnkit\
-ExecStart=/mnt/c/Windows/system32/wsl.exe -d wsl-vpnkit --cd /app GVPROXY_PATH=/mnt/c/git/wsl-vpnkit/wsl-gvproxy.exe wsl-vpnkit
+ExecStart=/mnt/c/Windows/system32/wsl.exe -d wsl-vpnkit --cd /app wsl-vpnkit
 
 # for wsl-vpnkit setup as a standalone script
 #ExecStart=/full/path/to/wsl-vpnkit

--- a/containers/wsl-java17.Containerfile
+++ b/containers/wsl-java17.Containerfile
@@ -1,6 +1,7 @@
 FROM rhelubi9:wsl
 
 ARG MAVEN_VERSION=3.9.5
+ARG TINKEY_VERSION=1.10.1
 
 RUN dnf update -y \
         && \
@@ -15,3 +16,10 @@ RUN tar xzf /tmp/maven/apache-maven-*.tar.gz -C /tmp/maven/ && \
     mv /tmp/maven/apache-maven-${MAVEN_VERSION} /opt/apache-maven && \
     alternatives --install /usr/local/bin/mvn mvn /opt/apache-maven/bin/mvn 1 && \
     rm -rf /tmp/maven
+
+# Install Google Tinkey
+ADD https://storage.googleapis.com/tinkey/tinkey-${TINKEY_VERSION}.tar.gz /tmp/tinkey/
+RUN tar xzf /tmp/tinkey/tinkey-*.tar.gz -C /tmp/tinkey/ && \
+    install -o root -g root -m 0755 /tmp/tinkey/tinkey /usr/local/bin/tinkey && \
+    install -o root -g root -m 0755 /tmp/tinkey/tinkey_deploy.jar /usr/local/bin/tinkey_deploy.jar && \
+    rm -rf /tmp/tinkey

--- a/containers/wsl.Containerfile
+++ b/containers/wsl.Containerfile
@@ -1,10 +1,11 @@
 FROM rhelubi9:dev-base
+ARG GIT_CREDENTIAL_MANAGER_PATH="/mnt/c/Program\ Files/Git/mingw64/bin/git-credential-manager.exe"
 
 # Enable systemd
 RUN crudini --set /etc/wsl.conf boot systemd true
 
 # Set up Git at system level to use Windows Git Credential Manager
-RUN git config --system credential.helper "/mnt/c/Program\ Files/Git/mingw64/bin/git-credential-manager.exe"
+RUN git config --system credential.helper "$GIT_CREDENTIAL_MANAGER_PATH"
 
 # Add and enable wsl-vpnkit service
 RUN cp /etc/extras/systemd/wsl-vpnkit.service /etc/systemd/system/ && \

--- a/install-vpnkit.ps1
+++ b/install-vpnkit.ps1
@@ -12,7 +12,3 @@ wsl --import wsl-vpnkit --version 2 $env:USERPROFILE\.wsl\wsl-vpnkit $env:USERPR
 # enable [automount] in wsl.conf for wsl-vpnkit distro and kill it so that it will restart correctly
 wsl --distribution wsl-vpnkit --cd /app sed -i '/^\[automount\]$/,/^\[/ s/^enabled[ ]\{0,\}=.*/enabled=true/' /etc/wsl.conf
 wsl --terminate wsl-vpnkit
-
-# copy wsl-gvproxy.exe to C:\git (otherwise it will be blocked by AppLocker)
-mkdir "C:\git\wsl-vpnkit"
-wsl --distribution wsl-vpnkit cp /app/wsl-gvproxy.exe /mnt/c/git/wsl-vpnkit/


### PR DESCRIPTION
Adds [Google's Tinkey CLI](https://developers.google.com/tink/tinkey-overview) to the Java-based WSL image since we are using it with https://github.com/hpgrahsl/kryptonite-for-kafka